### PR TITLE
feat: road bicycle

### DIFF
--- a/src/bicycles/index.ts
+++ b/src/bicycles/index.ts
@@ -1,0 +1,1 @@
+export * from './road';

--- a/src/bicycles/road.ts
+++ b/src/bicycles/road.ts
@@ -1,0 +1,5 @@
+export class RoadBicycle {
+  public pedal() {
+    return 'pedaling';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,6 @@ export class Hello {
     return 'hello, world!';
   }
 }
+
+// export submodules
+export * as bicycles from './bicycles';


### PR DESCRIPTION
`API.md` only contains documentation for `Hello` but not `RoadBicycle`, which is in the submodule `bicycles`

Nothing seemed to go wrong in the `jsii-docgen` portion of `npx projen build`:
```
👾 build » post-compile » docgen | jsii-docgen
Debugger listening on ws://127.0.0.1:49709/9fab139e-cfd8-40e5-b60c-8cc7d5892a3f
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Waiting for the debugger to disconnect...
```